### PR TITLE
modify fib even calculation

### DIFF
--- a/3_fibonaccis.py
+++ b/3_fibonaccis.py
@@ -82,12 +82,11 @@ def main():
     print(f'\nrecursing fibonacci values up to {limit}: ')
     help.multiline_print(flist)
 
-    limit = 5720992
-    start_list = fibonacci_iter(100)
+    limit = 51235324
+    start_list = fibonacci_iter(limit)
     even_flist = fibonacci_even(start_list)
-    flist = fibonacci_recurse(even_flist, limit)
     print(f'\neven fibonacci values up to {limit}: ')
-    help.multiline_print(flist, 2)
+    help.multiline_print(even_flist)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Originally calculated first 10 fibonacci numbers, even values from the original 10, then used fib-style calculation to expand values.

This change returns even values that are all in the fibonacci sequence